### PR TITLE
Switching openmina exec for mina

### DIFF
--- a/mina-node-orchestrator/templates/minarustplain.yaml.gotmpl
+++ b/mina-node-orchestrator/templates/minarustplain.yaml.gotmpl
@@ -22,7 +22,7 @@ daemon:
       #!/usr/bin/env bash
       
       set -euo pipefail
-      exec openmina node \
+      exec mina node \
       --verbosity=info \
       --peer-list-url={{ $peerList }}
   {{- end }}

--- a/mina-node-orchestrator/templates/minarustseed.yaml.gotmpl
+++ b/mina-node-orchestrator/templates/minarustseed.yaml.gotmpl
@@ -15,7 +15,7 @@ daemon:
       #!/usr/bin/env bash
       
       set -euo pipefail
-      exec openmina node \
+      exec mina node \
       --seed \
       --verbosity=info \
       --port={{ .node.values.daemon.ports.external.containerPort }} \


### PR DESCRIPTION
We are defaulting to `o1labs/mina-rust` artifacts, therefore the `minarustplain` and `minarustseed` default command args need to change.