### PR TITLE
chore: update chart maintainer from personal to o1-labs org

### DIFF
--- a/mina-daemon-chart/Chart.yaml
+++ b/mina-daemon-chart/Chart.yaml
@@ -25,9 +25,9 @@ appVersion: "0.0.1"
 
 # List of maintainers for this chart
 maintainers:
-  - name: "SanabriaRusso"
+  - name: "o1-labs"
     email: "luis@o1labs.org"
-    url: "https://github.com/SanabriaRusso"
+    url: "https://github.com/o1-labs"
 
 dependencies:
   - name: postgresql


### PR DESCRIPTION
  Prepare repository for ownership transfer to o1-labs GitHub organization.